### PR TITLE
테마별 학습 기능 구현 완료

### DIFF
--- a/src/main/java/com/example/jammoney/ThemeLearning/controller/ThemeController.java
+++ b/src/main/java/com/example/jammoney/ThemeLearning/controller/ThemeController.java
@@ -1,0 +1,20 @@
+package com.example.jammoney.ThemeLearning.controller;
+
+import com.example.jammoney.ThemeLearning.dto.ThemeDto;
+import com.example.jammoney.ThemeLearning.service.ThemeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class ThemeController {
+    private final ThemeService themeService;
+
+    @GetMapping("/api/themes")
+    public List<ThemeDto> getThemes() {
+        return themeService.getAllThemes();
+    }
+}

--- a/src/main/java/com/example/jammoney/ThemeLearning/controller/TopicController.java
+++ b/src/main/java/com/example/jammoney/ThemeLearning/controller/TopicController.java
@@ -1,0 +1,28 @@
+package com.example.jammoney.ThemeLearning.controller;
+
+import com.example.jammoney.ThemeLearning.dto.ThemeDto;
+import com.example.jammoney.ThemeLearning.dto.TopicDetailDto;
+import com.example.jammoney.ThemeLearning.dto.TopicListDto;
+import com.example.jammoney.ThemeLearning.service.LearningTopicService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class TopicController {
+    private final LearningTopicService topicService;
+
+    @GetMapping("/api/themes/{themeId}/topics")
+    public List<TopicListDto> getTopics(@PathVariable Long themeId) {
+        return topicService.getAllTopics(themeId);
+    }
+
+    @GetMapping("/api/themes/{themeId}/topics/{topicId}/details")
+    public TopicDetailDto getDetails(@PathVariable long topicId) {
+        return topicService.getTopicDetail(topicId);
+    }
+}

--- a/src/main/java/com/example/jammoney/ThemeLearning/dto/ThemeDto.java
+++ b/src/main/java/com/example/jammoney/ThemeLearning/dto/ThemeDto.java
@@ -1,5 +1,10 @@
 package com.example.jammoney.ThemeLearning.dto;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class ThemeDto {
     private Long themeId;
     private String name;

--- a/src/main/java/com/example/jammoney/ThemeLearning/dto/TopicDetailDto.java
+++ b/src/main/java/com/example/jammoney/ThemeLearning/dto/TopicDetailDto.java
@@ -1,5 +1,10 @@
 package com.example.jammoney.ThemeLearning.dto;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class TopicDetailDto {
     private Long topicId;
     private String title;

--- a/src/main/java/com/example/jammoney/ThemeLearning/dto/TopicListDto.java
+++ b/src/main/java/com/example/jammoney/ThemeLearning/dto/TopicListDto.java
@@ -1,5 +1,10 @@
 package com.example.jammoney.ThemeLearning.dto;
 
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
 public class TopicListDto {
     private Long topicId;
     private String title;

--- a/src/main/java/com/example/jammoney/ThemeLearning/models/LearningTopic.java
+++ b/src/main/java/com/example/jammoney/ThemeLearning/models/LearningTopic.java
@@ -18,6 +18,9 @@ public class LearningTopic {
 
     @Column(nullable = false, unique = true)
     private String title;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
     private String description;
 
     @ManyToOne

--- a/src/main/java/com/example/jammoney/ThemeLearning/repository/LearningTopicRepository.java
+++ b/src/main/java/com/example/jammoney/ThemeLearning/repository/LearningTopicRepository.java
@@ -1,7 +1,11 @@
 package com.example.jammoney.ThemeLearning.repository;
 
 import com.example.jammoney.ThemeLearning.models.LearningTopic;
+import com.example.jammoney.ThemeLearning.models.Theme;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LearningTopicRepository extends JpaRepository<LearningTopic, Long> {
+    List<LearningTopic> findByTheme(Theme theme);
 }

--- a/src/main/java/com/example/jammoney/ThemeLearning/repository/ThemeRepository.java
+++ b/src/main/java/com/example/jammoney/ThemeLearning/repository/ThemeRepository.java
@@ -3,8 +3,10 @@ package com.example.jammoney.ThemeLearning.repository;
 import com.example.jammoney.ThemeLearning.models.Theme;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ThemeRepository extends JpaRepository<Theme, Long> {
     Optional<Theme> findByName(String name);
+    List<Theme> findAllByOrderByIdAsc();
 }

--- a/src/main/java/com/example/jammoney/ThemeLearning/service/LearningTopicService.java
+++ b/src/main/java/com/example/jammoney/ThemeLearning/service/LearningTopicService.java
@@ -1,0 +1,45 @@
+package com.example.jammoney.ThemeLearning.service;
+
+import com.example.jammoney.ThemeLearning.dto.ThemeDto;
+import com.example.jammoney.ThemeLearning.dto.TopicDetailDto;
+import com.example.jammoney.ThemeLearning.dto.TopicListDto;
+import com.example.jammoney.ThemeLearning.models.LearningTopic;
+import com.example.jammoney.ThemeLearning.models.Theme;
+import com.example.jammoney.ThemeLearning.repository.LearningTopicRepository;
+import com.example.jammoney.ThemeLearning.repository.ThemeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LearningTopicService {
+    private final ThemeRepository themeRepository;
+    private final LearningTopicRepository topicRepository;
+
+    public List<TopicListDto> getAllTopics(Long themeId) {
+        Theme theme = themeRepository.findById(themeId)
+                .orElseThrow(() -> new RuntimeException("해당 카테고리가 없습니다"));
+
+        return topicRepository.findByTheme(theme).stream()
+                .map(topic -> {
+                    TopicListDto dto = new TopicListDto();
+                    dto.setTopicId(topic.getId());
+                    dto.setTitle(topic.getTitle());
+                    return dto;
+                })
+                .toList();
+    }
+
+    public TopicDetailDto getTopicDetail(Long topicId) {
+        LearningTopic topic = topicRepository.findById(topicId)
+                .orElseThrow(() -> new RuntimeException("해당 토픽이 없습니다"));
+
+        TopicDetailDto dto = new TopicDetailDto();
+        dto.setTopicId(topic.getId());
+        dto.setTitle(topic.getTitle());
+        dto.setDescription(topic.getDescription());
+        return dto;
+    }
+}

--- a/src/main/java/com/example/jammoney/ThemeLearning/service/ThemeService.java
+++ b/src/main/java/com/example/jammoney/ThemeLearning/service/ThemeService.java
@@ -1,0 +1,25 @@
+package com.example.jammoney.ThemeLearning.service;
+
+import com.example.jammoney.ThemeLearning.dto.ThemeDto;
+import com.example.jammoney.ThemeLearning.repository.ThemeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ThemeService {
+    private final ThemeRepository themeRepository;
+
+    public List<ThemeDto> getAllThemes() {
+        return themeRepository.findAllByOrderByIdAsc().stream()
+                .map(theme -> {
+                    ThemeDto dto = new ThemeDto();
+                    dto.setThemeId(theme.getId());
+                    dto.setName(theme.getName());
+                    return dto;
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/example/jammoney/financeTerm/models/UserTermLearning.java
+++ b/src/main/java/com/example/jammoney/financeTerm/models/UserTermLearning.java
@@ -1,5 +1,6 @@
 package com.example.jammoney.financeTerm.models;
 
+import com.example.jammoney.User.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -17,11 +18,11 @@ public class UserTermLearning {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /*
+
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
-     */
+
 
     @ManyToOne
     @JoinColumn(name = "term_id")

--- a/src/test/java/com/example/jammoney/ThemeLearningTest/LearningTopicServiceTest.java
+++ b/src/test/java/com/example/jammoney/ThemeLearningTest/LearningTopicServiceTest.java
@@ -1,0 +1,86 @@
+package com.example.jammoney.ThemeLearningTest;
+
+import com.example.jammoney.ThemeLearning.dto.TopicDetailDto;
+import com.example.jammoney.ThemeLearning.dto.TopicListDto;
+import com.example.jammoney.ThemeLearning.models.LearningTopic;
+import com.example.jammoney.ThemeLearning.models.Theme;
+import com.example.jammoney.ThemeLearning.repository.LearningTopicRepository;
+import com.example.jammoney.ThemeLearning.repository.ThemeRepository;
+import com.example.jammoney.ThemeLearning.service.LearningTopicService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LearningTopicServiceTest {
+    private ThemeRepository themeRepository;
+    private LearningTopicRepository topicRepository;
+    private LearningTopicService topicService;
+
+    @BeforeEach
+    void setup() {
+        themeRepository = mock(ThemeRepository.class);
+        topicRepository = mock(LearningTopicRepository.class);
+        topicService = new LearningTopicService(themeRepository, topicRepository);
+    }
+
+    @Test
+    void getAllTopicsReturn() {
+        Theme theme = Theme.builder().id(1L).name("저축").build();
+
+        LearningTopic topic1 = LearningTopic.builder()
+                .id(1L).title("첫 월급 관리법: 저축 vs 투자").theme(theme).build();
+        LearningTopic topic2 = LearningTopic.builder()
+                .id(2L).title("월급 재테크: 자동이체로 돈 모으기").theme(theme).build();
+        when(themeRepository.findById(1L)).thenReturn(Optional.of(theme));
+        when(topicRepository.findByTheme(theme)).thenReturn(Arrays.asList(topic1, topic2));
+
+        List<TopicListDto> result = topicService.getAllTopics(1L);
+        assertEquals(2, result.size());
+        assertEquals("첫 월급 관리법: 저축 vs 투자", result.get(0).getTitle());
+        assertEquals(1L, result.get(0).getTopicId());
+        assertEquals("월급 재테크: 자동이체로 돈 모으기", result.get(1).getTitle());
+        assertEquals(2L, result.get(1).getTopicId());
+    }
+
+    @Test
+    void getTopicDetailReturn() {
+        LearningTopic topic = LearningTopic.builder()
+                .id(1L)
+                .title("첫 월급 관리법: 저축 vs 투자")
+                .description("첫 월급은 단순한 수입이 아니라, 평생을 이어갈 재정 습관의 시작점입니다. ")
+                .build();
+
+        when(topicRepository.findById(1L)).thenReturn(Optional.of(topic));
+        TopicDetailDto dto = topicService.getTopicDetail(1L);
+        assertEquals("첫 월급 관리법: 저축 vs 투자", dto.getTitle());
+        assertEquals("첫 월급은 단순한 수입이 아니라, 평생을 이어갈 재정 습관의 시작점입니다. ", dto.getDescription());
+        assertEquals(1L, dto.getTopicId());
+    }
+
+    @Test
+    void getAllTopics_ThrowsException() {
+        when(themeRepository.findById(100L)).thenReturn(Optional.empty());
+        RuntimeException e = assertThrows(RuntimeException.class, () -> {
+            topicService.getAllTopics(100L);
+        });
+        assertEquals("해당 카테고리가 없습니다", e.getMessage());
+    }
+
+    @Test
+    void getTopicDetailThrowsException() {
+        when(topicRepository.findById(100L)).thenReturn(Optional.empty());
+        RuntimeException e = assertThrows(RuntimeException.class, () -> {
+            topicService.getTopicDetail(100L);
+        });
+        assertEquals("해당 토픽이 없습니다", e.getMessage());
+    }
+}

--- a/src/test/java/com/example/jammoney/ThemeLearningTest/ThemeControllerTest.java
+++ b/src/test/java/com/example/jammoney/ThemeLearningTest/ThemeControllerTest.java
@@ -1,0 +1,51 @@
+package com.example.jammoney.ThemeLearningTest;
+
+import com.example.jammoney.ThemeLearning.controller.ThemeController;
+import com.example.jammoney.ThemeLearning.dto.ThemeDto;
+import com.example.jammoney.ThemeLearning.service.ThemeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ThemeControllerTest {
+
+    private MockMvc mockMvc;
+    private ThemeService themeService;
+
+    @BeforeEach
+    void setup() {
+        themeService = mock(ThemeService.class);
+        ThemeController controller = new ThemeController(themeService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void getThemesReturn() throws Exception {
+        ThemeDto theme1 = new ThemeDto();
+        theme1.setThemeId(1L);
+        theme1.setName("저축");
+
+        ThemeDto theme2 = new ThemeDto();
+        theme2.setThemeId(2L);
+        theme2.setName("투자");
+
+        List<ThemeDto> mockThemes = List.of(theme1, theme2);
+        when(themeService.getAllThemes()).thenReturn(mockThemes);
+
+        mockMvc.perform(get("/api/themes"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(2))
+                .andExpect(jsonPath("$[0].name").value("저축"))
+                .andExpect(jsonPath("$[1].name").value("투자"));
+    }
+}

--- a/src/test/java/com/example/jammoney/ThemeLearningTest/TopicControllerTest.java
+++ b/src/test/java/com/example/jammoney/ThemeLearningTest/TopicControllerTest.java
@@ -1,0 +1,70 @@
+package com.example.jammoney.ThemeLearningTest;
+
+import com.example.jammoney.ThemeLearning.controller.ThemeController;
+import com.example.jammoney.ThemeLearning.controller.TopicController;
+import com.example.jammoney.ThemeLearning.dto.TopicDetailDto;
+import com.example.jammoney.ThemeLearning.dto.TopicListDto;
+import com.example.jammoney.ThemeLearning.service.LearningTopicService;
+import com.example.jammoney.ThemeLearning.service.ThemeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class TopicControllerTest {
+    private MockMvc mockMvc;
+    private LearningTopicService topicService;
+
+    @BeforeEach
+    void setup() {
+        topicService = Mockito.mock(LearningTopicService.class);
+        TopicController controller = new TopicController(topicService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void getTopicsReturn() throws Exception {
+        TopicListDto topic1 = new TopicListDto();
+        topic1.setTopicId(1L);
+        topic1.setTitle("첫 월급 관리법: 저축 vs 투자");
+
+        TopicListDto topic2 = new TopicListDto();
+        topic2.setTopicId(2L);
+        topic2.setTitle("월급 재테크: 자동이체로 돈 모으기");
+
+        List<TopicListDto> topicList = Arrays.asList(topic1, topic2);
+        when(topicService.getAllTopics(1L)).thenReturn(topicList);
+
+        mockMvc.perform(get("/api/themes/1/topics"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.size()").value(2))
+                .andExpect(jsonPath("$[0].topicId").value(1))
+                .andExpect(jsonPath("$[0].title").value("첫 월급 관리법: 저축 vs 투자"))
+                .andExpect(jsonPath("$[1].topicId").value(2))
+                .andExpect(jsonPath("$[1].title").value("월급 재테크: 자동이체로 돈 모으기"));
+    }
+
+    @Test
+    void getTopicDetailReturn() throws Exception {
+        TopicDetailDto detail = new TopicDetailDto();
+        detail.setTopicId(1L);
+        detail.setTitle("첫 월급 관리법: 저축 vs 투자");
+        detail.setDescription("첫 월급은 단순한 수입이 아니라, 평생을 이어갈 재정 습관의 시작점입니다.");
+        when(topicService.getTopicDetail(1L)).thenReturn(detail);
+
+        mockMvc.perform(get("/api/themes/1/topics/1/details"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.topicId").value(1))
+                .andExpect(jsonPath("$.title").value("첫 월급 관리법: 저축 vs 투자"))
+                .andExpect(jsonPath("$.description").value("첫 월급은 단순한 수입이 아니라, 평생을 이어갈 재정 습관의 시작점입니다."));
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목

- [Feature] 테마별 학습 기능 구현

## 🛠️ 작업한 기능
- 카테고리 리스트 조회 API 구현
- 카테고리별 토픽 리스트 조회 API 구현
- 학습 내용 상세 조회 API 구현

## ✅ 테스트 내역
Postman 테스트
- /api/themes 호출하여 카테고리 리스트 정상 조회 (200 OK) 확인
- /api/themes/{themeId}/topics 호출하여 토픽 리스트 정상 조회 (200 OK) 확인
- /api/themes/{themeId}/topics/{topicId}/details 호출하여 학습 내용 정상 조회 (200 OK) 확인

단위 테스트 코드 
- ThemeControllerTest를 통해 카테고리 목록 API의 응답 구조 및 값 검증
- TopicControllerTest를 통해 토픽 리스트 및 학습 내용 응답 값 검증