### PR TITLE
테마별학습 등록 api 구현 완료 

### DIFF
--- a/src/main/java/com/example/jammoney/financeTerm/entity/FinancialTerm.java
+++ b/src/main/java/com/example/jammoney/financeTerm/entity/FinancialTerm.java
@@ -25,6 +25,8 @@ public class FinancialTerm {
 
     private String category;
 
+    private int dayIndex;
+
     @ElementCollection
     @OrderColumn(name = "sequence")
     private List<String> exampleSentences;

--- a/src/main/java/com/example/jammoney/financeTerm/entity/UserSavedTerm.java
+++ b/src/main/java/com/example/jammoney/financeTerm/entity/UserSavedTerm.java
@@ -1,5 +1,6 @@
 package com.example.jammoney.financeTerm.entity;
 
+import com.example.jammoney.User.User;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -16,11 +17,11 @@ public class UserSavedTerm {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /*
+
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
-    */
+
 
     @ManyToOne
     @JoinColumn(name = "term_id")

--- a/src/main/java/com/example/jammoney/financeTerm/entity/UserTermLearning.java
+++ b/src/main/java/com/example/jammoney/financeTerm/entity/UserTermLearning.java
@@ -6,7 +6,9 @@ import lombok.*;
 
 
 @Entity
-@Table(name = "user_term_learnings")
+@Table(name = "user_term_learnings", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "term_id"})
+})
 @Getter
 @Setter
 @NoArgsConstructor
@@ -29,4 +31,6 @@ public class UserTermLearning {
     private FinancialTerm term;
 
     private boolean learned;
+
+    private boolean expGiven;
 }

--- a/src/main/java/com/example/jammoney/financeTerm/repository/SavedTermRepository.java
+++ b/src/main/java/com/example/jammoney/financeTerm/repository/SavedTermRepository.java
@@ -1,0 +1,14 @@
+package com.example.jammoney.financeTerm.repository;
+
+import com.example.jammoney.User.User;
+import com.example.jammoney.financeTerm.entity.FinancialTerm;
+import com.example.jammoney.financeTerm.entity.UserSavedTerm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SavedTermRepository extends JpaRepository<UserSavedTerm, Long> {
+    List<UserSavedTerm> findAllByUser(User user); // 사용자가 북마크한 단어 전체 조회
+    Optional<UserSavedTerm> findByUserAndTerm(User user, FinancialTerm term); // 단어가 북마크되어 있는지 확인
+}

--- a/src/main/java/com/example/jammoney/financeTerm/repository/TermQuizRepository.java
+++ b/src/main/java/com/example/jammoney/financeTerm/repository/TermQuizRepository.java
@@ -1,0 +1,11 @@
+package com.example.jammoney.financeTerm.repository;
+
+import com.example.jammoney.financeTerm.entity.FinancialTerm;
+import com.example.jammoney.financeTerm.entity.FinancialTermQuiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TermQuizRepository extends JpaRepository<FinancialTermQuiz, Long> {
+    List<FinancialTermQuiz> findByTerm(FinancialTerm term); // 단어에 연결된 퀴즈들 불러오기
+}

--- a/src/main/java/com/example/jammoney/financeTerm/repository/TermRepository.java
+++ b/src/main/java/com/example/jammoney/financeTerm/repository/TermRepository.java
@@ -1,0 +1,10 @@
+package com.example.jammoney.financeTerm.repository;
+
+import com.example.jammoney.financeTerm.entity.FinancialTerm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TermRepository extends JpaRepository<FinancialTerm, Long> {
+    List<FinancialTerm> findByCategoryAndDayIndex(String category, int dayIndex); // 카테고리 + Day 묶음으로 5개 단어 조회
+}

--- a/src/main/java/com/example/jammoney/financeTerm/repository/UserLearningRepository.java
+++ b/src/main/java/com/example/jammoney/financeTerm/repository/UserLearningRepository.java
@@ -1,0 +1,15 @@
+package com.example.jammoney.financeTerm.repository;
+
+import com.example.jammoney.User.User;
+import com.example.jammoney.financeTerm.entity.FinancialTerm;
+import com.example.jammoney.financeTerm.entity.UserTermLearning;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserLearningRepository extends JpaRepository<UserTermLearning, Long> {
+    boolean existsByUserAndTerm(User user, FinancialTerm term); // 단어를 학습했는지 여부 확인
+    long countByUserAndLearnedTrue(User user);  // 전체 학습 완료한 단어 개수 (학습률)
+    List<UserTermLearning> findByUserAndTermIn(User user, List<FinancialTerm> terms);// Day 단위로 학습된 단어들 조회 (경험치 지급)
+}

--- a/src/main/java/com/example/jammoney/theme/controller/TopicController.java
+++ b/src/main/java/com/example/jammoney/theme/controller/TopicController.java
@@ -1,12 +1,12 @@
 package com.example.jammoney.theme.controller;
 
+import com.example.jammoney.theme.dto.TopicCreateDto;
 import com.example.jammoney.theme.dto.TopicDetailDto;
 import com.example.jammoney.theme.dto.TopicListDto;
+import com.example.jammoney.theme.entity.LearningTopic;
 import com.example.jammoney.theme.service.LearningTopicService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -23,5 +23,10 @@ public class TopicController {
     @GetMapping("/api/themes/{themeId}/topics/{topicId}/details")
     public TopicDetailDto getDetails(@PathVariable long topicId) {
         return topicService.getTopicDetail(topicId);
+    }
+
+    @PostMapping("/api/themes/topics")
+    public void createTopic(@RequestBody TopicCreateDto createDto) {
+        topicService.createTopic(createDto);
     }
 }

--- a/src/main/java/com/example/jammoney/theme/dto/TopicCreateDto.java
+++ b/src/main/java/com/example/jammoney/theme/dto/TopicCreateDto.java
@@ -1,0 +1,12 @@
+package com.example.jammoney.theme.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TopicCreateDto {
+    private Long themeId;
+    private String title;
+    private String description;
+}

--- a/src/main/java/com/example/jammoney/theme/service/LearningTopicService.java
+++ b/src/main/java/com/example/jammoney/theme/service/LearningTopicService.java
@@ -1,5 +1,6 @@
 package com.example.jammoney.theme.service;
 
+import com.example.jammoney.theme.dto.TopicCreateDto;
 import com.example.jammoney.theme.dto.TopicDetailDto;
 import com.example.jammoney.theme.dto.TopicListDto;
 import com.example.jammoney.theme.entity.LearningTopic;
@@ -40,5 +41,18 @@ public class LearningTopicService {
         dto.setTitle(topic.getTitle());
         dto.setDescription(topic.getDescription());
         return dto;
+    }
+
+    public void createTopic(TopicCreateDto dto) {
+        Theme theme = themeRepository.findById(dto.getThemeId())
+                .orElseThrow(() -> new RuntimeException("해당 테마가 없습니다"));
+
+        LearningTopic topic = LearningTopic.builder()
+                .title(dto.getTitle())
+                .description(dto.getDescription())
+                .theme(theme)
+                .build();
+
+        topicRepository.save(topic);
     }
 }

--- a/src/test/java/com/example/jammoney/ThemeLearningTest/LearningTopicServiceTest.java
+++ b/src/test/java/com/example/jammoney/ThemeLearningTest/LearningTopicServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.jammoney.ThemeLearningTest;
 
+import com.example.jammoney.theme.dto.TopicCreateDto;
 import com.example.jammoney.theme.dto.TopicDetailDto;
 import com.example.jammoney.theme.dto.TopicListDto;
 import com.example.jammoney.theme.entity.LearningTopic;
@@ -9,6 +10,7 @@ import com.example.jammoney.theme.repository.ThemeRepository;
 import com.example.jammoney.theme.service.LearningTopicService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.Arrays;
 import java.util.List;
@@ -16,8 +18,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class LearningTopicServiceTest {
     private ThemeRepository themeRepository;
@@ -63,6 +64,26 @@ public class LearningTopicServiceTest {
         assertEquals("첫 월급 관리법: 저축 vs 투자", dto.getTitle());
         assertEquals("첫 월급은 단순한 수입이 아니라, 평생을 이어갈 재정 습관의 시작점입니다. ", dto.getDescription());
         assertEquals(1L, dto.getTopicId());
+    }
+
+    @Test
+    void createTopicsOk() {
+        Theme theme = Theme.builder().id(1L).name("저축").build();
+        TopicCreateDto dto = new TopicCreateDto();
+        dto.setThemeId(1L);
+        dto.setTitle("청소년을 위한 금융기초");
+        dto.setDescription("청소년 눈높이에 맞춘 소비와 저축의 기초");
+        when(themeRepository.findById(1L)).thenReturn(Optional.of(theme));
+
+        topicService.createTopic(dto);
+
+        ArgumentCaptor<LearningTopic> captor = ArgumentCaptor.forClass(LearningTopic.class);
+        verify(topicRepository).save(captor.capture());
+
+        LearningTopic saved = captor.getValue();
+        assertEquals("청소년을 위한 금융기초", saved.getTitle());
+        assertEquals("청소년 눈높이에 맞춘 소비와 저축의 기초", saved.getDescription());
+        assertEquals(theme, saved.getTheme());
     }
 
     @Test

--- a/src/test/java/com/example/jammoney/ThemeLearningTest/TopicControllerTest.java
+++ b/src/test/java/com/example/jammoney/ThemeLearningTest/TopicControllerTest.java
@@ -1,12 +1,15 @@
 package com.example.jammoney.ThemeLearningTest;
 
 import com.example.jammoney.theme.controller.TopicController;
+import com.example.jammoney.theme.dto.TopicCreateDto;
 import com.example.jammoney.theme.dto.TopicDetailDto;
 import com.example.jammoney.theme.dto.TopicListDto;
 import com.example.jammoney.theme.service.LearningTopicService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -14,6 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -21,12 +25,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class TopicControllerTest {
     private MockMvc mockMvc;
     private LearningTopicService topicService;
+    private ObjectMapper objectMapper;
 
     @BeforeEach
     void setup() {
         topicService = Mockito.mock(LearningTopicService.class);
         TopicController controller = new TopicController(topicService);
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        objectMapper = new ObjectMapper();
     }
 
     @Test
@@ -65,4 +71,21 @@ public class TopicControllerTest {
                 .andExpect(jsonPath("$.title").value("첫 월급 관리법: 저축 vs 투자"))
                 .andExpect(jsonPath("$.description").value("첫 월급은 단순한 수입이 아니라, 평생을 이어갈 재정 습관의 시작점입니다."));
     }
+
+    @Test
+    void createTopicReturnOk() throws Exception {
+        TopicCreateDto dto = new TopicCreateDto();
+        dto.setThemeId(1L);
+        dto.setTitle("청소년을 위한 금융기초");
+        dto.setDescription("청소년 눈높이에 맞춘 소비와 저축의 기초");
+
+        String json = objectMapper.writeValueAsString(dto);
+
+        mockMvc.perform(org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                        .post("/api/themes/topics")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk());
+    }
+
 }


### PR DESCRIPTION
## 📌 PR 제목
[Feature] 테마별 학습 등록 API 구현

🛠️ 작업한 기능
- 테마에 속하는 학습 토픽 등록 기능 구현
- /api/themes/topics POST API 개발
- TopicCreateDto 생성 

✅ 테스트 내역
- Postman으로 POST 요청 테스트 (200 OK 응답 확인)
- TopicControllerTest에 POST API 테스트 추가
- LearningTopicServiceTest 테스트 추가
