### PR TITLE
CustomUserDetails 수정 및 PetServiceTest 코드 수정

### DIFF
--- a/src/main/java/com/example/jammoney/auth/controller/AuthController.java
+++ b/src/main/java/com/example/jammoney/auth/controller/AuthController.java
@@ -36,7 +36,7 @@ public class AuthController {
 
         // 2. 인증된 사용자 정보 가져오기
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-        User user = userDetails.toUser();
+        User user = userDetails.getUser();
 
         // 3. AccessToken 생성
         String accessToken = jwtTokenProvider.generateAccessToken(user.getEmail());

--- a/src/main/java/com/example/jammoney/auth/entity/CustomUserDetails.java
+++ b/src/main/java/com/example/jammoney/auth/entity/CustomUserDetails.java
@@ -1,6 +1,7 @@
 package com.example.jammoney.auth.entity;
 
 import com.example.jammoney.user.entity.User;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -9,14 +10,21 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-public class CustomUserDetails extends User implements UserDetails {
+public class CustomUserDetails implements UserDetails {
+
+    // 사용자 정보에 접근하기 위한 getter
+    @Getter
+    private final User user;
     private final List<GrantedAuthority> authorities;
 
     public CustomUserDetails(User user) {
-        super(user.getId(), user.getEmail(), user.getPassword(), user.getNickname(), user.getRole(), user.isActive());
-        this.authorities = Collections.singletonList(new SimpleGrantedAuthority(user.getRole().name()));
+        this.user = user;
+        this.authorities = Collections.singletonList(
+                new SimpleGrantedAuthority(user.getRole().name())
+        );
     }
 
+    // UserDetails 필수 구현 메서드
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return authorities;
@@ -24,12 +32,12 @@ public class CustomUserDetails extends User implements UserDetails {
 
     @Override
     public String getPassword() {
-        return super.getPassword();
+        return user.getPassword();
     }
 
     @Override
     public String getUsername() {
-        return super.getEmail();
+        return user.getEmail(); // 로그인 시 사용할 사용자명 (보통 이메일)
     }
 
     @Override
@@ -49,15 +57,6 @@ public class CustomUserDetails extends User implements UserDetails {
 
     @Override
     public boolean isEnabled() {
-        return true;
+        return user.isActive();
     }
-
-    public User toUser() {
-        return new User(getId(), getEmail(), getPassword(), getNickname(), getRole(), isActive());
-    }
-
-    public User getUser() { return this; }
 }
-
-
-

--- a/src/main/java/com/example/jammoney/pet/controller/ItemController.java
+++ b/src/main/java/com/example/jammoney/pet/controller/ItemController.java
@@ -24,13 +24,13 @@ public class ItemController {
     private final UserRepository userRepository;
 
     // 현재 로그인한 유저를 DB에서 다시 가져오는 유틸 메서드
-    private User getCurrentUser() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
-
-        return userRepository.findById(principal.getId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
-    }
+//    private User getCurrentUser() {
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//        CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
+//
+//        return userRepository.findById(principal.getId())
+//                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+//    }
 
     // 상점 아이템 전체 조회 (모두에게 허용)
     @GetMapping("/shop")
@@ -41,24 +41,27 @@ public class ItemController {
 
     // 아이템 구매
     @PostMapping("/purchase")
-    public ResponseEntity<ApiResponse<Void>> purchaseItem(@RequestBody ItemPurchaseRequestDTO request) {
-        User user = getCurrentUser();
+    public ResponseEntity<ApiResponse<Void>> purchaseItem(@RequestBody ItemPurchaseRequestDTO request,@AuthenticationPrincipal CustomUserDetails userDetails ) {
+        //User user = getCurrentUser();
+        User user = userDetails.getUser();
         itemService.purchaseItem(user, request.getItemId());
         return ResponseEntity.ok(ApiResponse.success("아이템을 성공적으로 구매했습니다.", null));
     }
 
     // 인벤토리 조회
     @GetMapping("/inventory")
-    public ResponseEntity<ApiResponse<List<InventoryResponseDTO>>> getInventory() {
-        User user = getCurrentUser();
+    public ResponseEntity<ApiResponse<List<InventoryResponseDTO>>> getInventory(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        //User user = getCurrentUser();
+        User user = userDetails.getUser();
         List<InventoryResponseDTO> inventory = itemService.getUserInventory(user);
         return ResponseEntity.ok(ApiResponse.success("인벤토리 조회 성공", inventory));
     }
 
     // 아이템 장착/해제
     @PostMapping("/equip")
-    public ResponseEntity<ApiResponse<Void>> equipItem(@RequestBody ItemEquipRequestDTO request) {
-        User user = getCurrentUser();
+    public ResponseEntity<ApiResponse<Void>> equipItem(@RequestBody ItemEquipRequestDTO request,@AuthenticationPrincipal CustomUserDetails userDetails) {
+        //User user = getCurrentUser();
+        User user = userDetails.getUser();
         itemService.equipItem(user, request.getItemId(), request.isEquip());
         String message = request.isEquip() ? "아이템 장착 완료" : "아이템 해제 완료";
         return ResponseEntity.ok(ApiResponse.success(message, null));
@@ -66,8 +69,9 @@ public class ItemController {
 
     // 아이템 판매
     @PostMapping("/sell")
-    public ResponseEntity<ApiResponse<Void>> sellItem(@RequestBody ItemSellRequestDTO request) {
-        User user = getCurrentUser();
+    public ResponseEntity<ApiResponse<Void>> sellItem(@RequestBody ItemSellRequestDTO request,@AuthenticationPrincipal CustomUserDetails userDetails) {
+        //User user = getCurrentUser();
+        User user = userDetails.getUser();
         itemService.sellItem(user, request.getItemId());
         return ResponseEntity.ok(ApiResponse.success("아이템 판매 완료", null));
     }

--- a/src/main/java/com/example/jammoney/pet/controller/PetController.java
+++ b/src/main/java/com/example/jammoney/pet/controller/PetController.java
@@ -23,26 +23,27 @@ public class PetController {
     private final UserRepository userRepository;
 
     // 현재 로그인한 유저를 DB에서 다시 가져오는 유틸 메서드
-    private User getCurrentUser() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
-
-        return userRepository.findById(principal.getId())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
-    }
+//    private User getCurrentUser() {
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//        CustomUserDetails principal = (CustomUserDetails) authentication.getPrincipal();
+//
+//        return userRepository.findById(principal.getId())
+//                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+//    }
 
     // 캐릭터 상태 조회
     @GetMapping("/status")
-    public ResponseEntity<ApiResponse<PetStatusResponseDTO>> getPetStatus() {
-        User user = getCurrentUser();
+    public ResponseEntity<ApiResponse<PetStatusResponseDTO>> getPetStatus(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        User user = userDetails.getUser();
         PetStatusResponseDTO status = petService.getPetStatus(user);
         return ResponseEntity.ok(ApiResponse.success("캐릭터 상태 조회 성공", status));
     }
 
     // 캐릭터 이름 변경
     @PostMapping("/rename")
-    public ResponseEntity<ApiResponse<Void>> renamePet(@RequestBody PetRenameRequestDTO request) {
-        User user = getCurrentUser();
+    public ResponseEntity<ApiResponse<Void>> renamePet(@RequestBody PetRenameRequestDTO request, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        //User user = getCurrentUser();
+        User user = userDetails.getUser();
         petService.renamePet(user, request.getNewName());
         return ResponseEntity.ok(ApiResponse.success("캐릭터 이름 변경 완료", null));
     }

--- a/src/main/java/com/example/jammoney/user/controller/UserController.java
+++ b/src/main/java/com/example/jammoney/user/controller/UserController.java
@@ -19,7 +19,7 @@ public class UserController {
     //현재 로그인한 사용자 정보 조회
     @GetMapping("/me")
     public ResponseEntity<UserProfileDto> getCurrentUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        User user = userDetails.toUser();  // CustomUserDetails 내부에 toUser() 메서드 있어야 함
+        User user = userDetails.getUser();
         return ResponseEntity.ok(new UserProfileDto(user));
     }
 

--- a/src/test/java/com/example/jammoney/PetServiceTest.java
+++ b/src/test/java/com/example/jammoney/PetServiceTest.java
@@ -28,7 +28,8 @@ class PetServiceTest {
     void 이름_정상_변경() {
         User user = User.builder().id(1L).build();
         Pet pet = Pet.builder().name("공룡이").build();
-        Mockito.when(petRepository.findByUserId(1L)).thenReturn(pet);
+        user.setPet(pet);
+        //Mockito.when(petRepository.findByUserId(1L)).thenReturn(pet);
 
         petService.renamePet(user, "마루");
 
@@ -40,7 +41,8 @@ class PetServiceTest {
     void 이름_null_예외() {
         User user = User.builder().id(1L).build();
         Pet pet = Pet.builder().build();
-        Mockito.when(petRepository.findByUserId(1L)).thenReturn(pet);
+        user.setPet(pet);
+        //Mockito.when(petRepository.findByUserId(1L)).thenReturn(pet);
 
         assertThrows(IllegalArgumentException.class, () -> {
             petService.renamePet(user, null);
@@ -51,7 +53,8 @@ class PetServiceTest {
     void 이름_공백_예외() {
         User user = User.builder().id(1L).build();
         Pet pet = Pet.builder().build();
-        Mockito.when(petRepository.findByUserId(1L)).thenReturn(pet);
+        user.setPet(pet);
+        //Mockito.when(petRepository.findByUserId(1L)).thenReturn(pet);
 
         assertThrows(IllegalArgumentException.class, () -> {
             petService.renamePet(user, "   ");
@@ -62,7 +65,8 @@ class PetServiceTest {
     void 이름_길이초과_예외() {
         User user = User.builder().id(1L).build();
         Pet pet = Pet.builder().build();
-        Mockito.when(petRepository.findByUserId(1L)).thenReturn(pet);
+        user.setPet(pet);
+        //Mockito.when(petRepository.findByUserId(1L)).thenReturn(pet);
 
         String longName = "이름이이이이이이이이이이이이이이이이이이이이";
         assertThrows(IllegalArgumentException.class, () -> {


### PR DESCRIPTION
## 📌 PR 제목
[hotfix] CustomUserDetails 수정 및 PetServiceTest 코드 수정

---

## 🛠️ 작업한 기능
- CustomUserDetails가 원래 User를 상속받는 구조였지만, 연관관계 사용을 위해서 CustomUserDetails 내에 User 필드를 생성하여, CustomUserDetails를 통해 user 객체를 참조할 수 있도록 변경
- PetServiceTest 코드에서, builder를 통해 user 객체와 pet 객체를 만들고 나서, 둘의 연관 관계 설정하는 코드 추가

<!-- 
예시:
- 퀴즈 정답 시 EXP 및 가상 머니 보상 로직 추가
- `/api/quiz/submit` API 구현 및 응답 구조 설계
-->

---

## ✅ 테스트 내역
- MockMVC 기반 테스트
![image](https://github.com/user-attachments/assets/72e93670-36a9-42d2-91d0-17738cf38212)

<!-- 
예시:
- Postman으로 퀴즈 제출 테스트 (200 OK 확인)
- 브라우저에서 UI 클릭 시 리워드 지급 정상 확인
-->

---
