### PR TITLE
Cash 증가 감소 로직 구현

### DIFF
--- a/src/main/java/com/example/jammoney/exception/CashNotFoundException.java
+++ b/src/main/java/com/example/jammoney/exception/CashNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.jammoney.exception;
+
+public class CashNotFoundException extends RuntimeException {
+  public CashNotFoundException() {
+    super(ErrorCode.CASH_NOT_FOUND.getMessage());
+  }
+
+  public ErrorCode getErrorCode() {
+    return ErrorCode.CASH_NOT_FOUND;
+  }
+}

--- a/src/main/java/com/example/jammoney/exception/ErrorCode.java
+++ b/src/main/java/com/example/jammoney/exception/ErrorCode.java
@@ -1,5 +1,7 @@
 package com.example.jammoney.exception;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
 @Getter
 public enum ErrorCode {
     PASSWORD_MISMATCH("비밀번호와 비밀번호 재입력이 일치하지 않습니다.",410),
@@ -7,7 +9,9 @@ public enum ErrorCode {
     VALIDATION_ERROR("요청 값이 유효하지 않습니다.", 400),
     INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.", 500),
     REFRESH_TOKEN_NOT_FOUND("리프레시 토큰이 존재하지 않습니다.", 401),
-    REFRESH_TOKEN_EXPIRED("리프레시 토큰이 만료되었습니다.", 401);
+    REFRESH_TOKEN_EXPIRED("리프레시 토큰이 만료되었습니다.", 401),
+    CASH_NOT_FOUND("해당 사용자의 Cash 정보가 없습니다.", 411),
+    INSUFFICIENT_BALANCE("잔액이 부족합니다.", 412);
     private final String message;
     private final int status;
 

--- a/src/main/java/com/example/jammoney/exception/InsufficientBalanceException.java
+++ b/src/main/java/com/example/jammoney/exception/InsufficientBalanceException.java
@@ -1,0 +1,11 @@
+package com.example.jammoney.exception;
+
+public class InsufficientBalanceException extends RuntimeException {
+    public InsufficientBalanceException() {
+        super(ErrorCode.INSUFFICIENT_BALANCE.getMessage());
+    }
+
+    public ErrorCode getErrorCode() {
+        return ErrorCode.INSUFFICIENT_BALANCE;
+    }
+}

--- a/src/main/java/com/example/jammoney/stockApp/stock/entity/Cash.java
+++ b/src/main/java/com/example/jammoney/stockApp/stock/entity/Cash.java
@@ -22,4 +22,15 @@ public class Cash{
     @OneToOne(fetch = FetchType.LAZY)
     private User user;
 
+    public void increase(long amount) {
+        if (amount < 0) throw new IllegalArgumentException("증가 금액은 0 이상이어야 합니다.");
+        this.money += amount;
+    }
+
+    public void decrease(long amount) {
+        if (amount < 0) throw new IllegalArgumentException("감소 금액은 0 이상이어야 합니다.");
+        if (this.money < amount) throw new IllegalStateException("잔액이 부족합니다.");
+        this.money -= amount;
+    }
+
 }

--- a/src/main/java/com/example/jammoney/stockApp/stock/repository/CashRepository.java
+++ b/src/main/java/com/example/jammoney/stockApp/stock/repository/CashRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface CashRepository extends JpaRepository<Cash, Long> {
     Optional<Cash> findByUser(User user);
+    Optional<Cash> findByUserId(Long userId);
 }

--- a/src/main/java/com/example/jammoney/stockApp/stock/service/CashService.java
+++ b/src/main/java/com/example/jammoney/stockApp/stock/service/CashService.java
@@ -1,0 +1,58 @@
+package com.example.jammoney.stockApp.stock.service;
+
+import com.example.jammoney.exception.CashNotFoundException;
+import com.example.jammoney.exception.InsufficientBalanceException;
+import com.example.jammoney.stockApp.stock.entity.Cash;
+import com.example.jammoney.stockApp.stock.repository.CashRepository;
+import com.example.jammoney.user.entity.User;
+import com.example.jammoney.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CashService {
+
+    private final CashRepository cashRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void createCash(Long userId, long initialAmount) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        if (user.getCash() != null) {
+            throw new IllegalStateException("이미 Cash 정보가 존재합니다.");
+        }
+
+        Cash cash = new Cash();
+        cash.setMoney(initialAmount);
+        cash.setUser(user);
+        user.setCash(cash); // 양방향 매핑
+
+        cashRepository.save(cash);
+    }
+    @Transactional
+    public void addCash(long userId, long amount) {
+        Cash cash = cashRepository.findByUserId(userId)
+                .orElseThrow(CashNotFoundException::new);
+        cash.increase(amount);
+    }
+
+    @Transactional
+    public void subtractCash(Long userId, long amount) {
+        Cash cash = cashRepository.findByUserId(userId)
+                .orElseThrow(CashNotFoundException::new);
+        if (cash.getMoney() < amount) {
+            throw new InsufficientBalanceException();
+        }
+        cash.decrease(amount);
+    }
+
+    public long getMoney(Long userId) {
+        return cashRepository.findByUserId(userId)
+                .map(Cash::getMoney)
+                .orElse(0L);
+    }
+}

--- a/src/test/java/com/example/jammoney/cash/CashServiceTest.java
+++ b/src/test/java/com/example/jammoney/cash/CashServiceTest.java
@@ -1,0 +1,61 @@
+package com.example.jammoney.cash;
+
+import com.example.jammoney.exception.InsufficientBalanceException;
+import com.example.jammoney.stockApp.stock.entity.Cash;
+import com.example.jammoney.stockApp.stock.service.CashService;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CashServiceTest {
+
+    private final CashService cashService = new CashService(null, null) {
+        @Override
+        public void addCash(long userId, long amount) {
+            Cash cash = new Cash();
+            cash.setMoney(1000L);
+            cash.increase(amount);
+            assertEquals(1300L, cash.getMoney());
+        }
+
+        @Override
+        public void subtractCash(Long userId, long amount) {
+            Cash cash = new Cash();
+            cash.setMoney(1000L);
+            if (cash.getMoney() < amount) {
+                throw new InsufficientBalanceException();
+            }
+            cash.decrease(amount);
+            assertEquals(700L, cash.getMoney());
+        }
+    };
+
+    @Test
+    void 캐시_증가_테스트() {
+        cashService.addCash(1L, 300L);
+    }
+
+    @Test
+    void 캐시_감소_테스트() {
+        cashService.subtractCash(1L, 300L);
+    }
+
+    @Test
+    void 캐시_감소_실패_테스트() {
+        CashService localService = new CashService(null, null) {
+            @Override
+            public void subtractCash(Long userId, long amount) {
+                Cash cash = new Cash();
+                cash.setMoney(100L);
+                if (cash.getMoney() < amount) {
+                    throw new InsufficientBalanceException();
+                }
+            }
+        };
+
+        assertThrows(InsufficientBalanceException.class, () -> {
+            localService.subtractCash(1L, 200L);
+        });
+    }
+}


### PR DESCRIPTION
## 📌 PR 제목

[feature] Cash 증가 감소 로직 구현

## 🛠️ 작업한 기능
- Cash 증가 감소에 대한 예외처리
- Cash 증가 감소 로직 구현
<!-- 
예시:
- 퀴즈 정답 시 EXP 및 가상 머니 보상 로직 추가
- `/api/quiz/submit` API 구현 및 응답 구조 설계
-->

---

## ✅ 테스트 내역
- Mock 기반 Service 단 테스트 진행
![image](https://github.com/user-attachments/assets/17333f5f-ddb9-444f-8a82-b8510bc70423)


<!-- 
예시:
- Postman으로 퀴즈 제출 테스트 (200 OK 확인)
- 브라우저에서 UI 클릭 시 리워드 지급 정상 확인
-->

---

## 📝 참고사항 (리뷰 시 유의할 점)
<!-- 
예시:
- DB 쿼리는 임시이며 추후 QueryDSL 전환 예정
- 프론트와 응답 구조 조율 필요
-->
cash 관련 코드 추후 패키지 이동 예정