### PR TITLE
테마별학습 태그 추가

### DIFF
--- a/src/main/java/com/example/jammoney/theme/dto/TopicCreateDto.java
+++ b/src/main/java/com/example/jammoney/theme/dto/TopicCreateDto.java
@@ -9,4 +9,5 @@ public class TopicCreateDto { //토픽 생성용 DTO
     private Long themeId;
     private String title;
     private String description;
+    private String tag;
 }

--- a/src/main/java/com/example/jammoney/theme/dto/TopicDetailDto.java
+++ b/src/main/java/com/example/jammoney/theme/dto/TopicDetailDto.java
@@ -9,5 +9,6 @@ public class TopicDetailDto { //토픽 상세 내용
     private Long topicId;
     private String title;
     private String description;
+    private String tag;
 }
 

--- a/src/main/java/com/example/jammoney/theme/dto/TopicListDto.java
+++ b/src/main/java/com/example/jammoney/theme/dto/TopicListDto.java
@@ -8,5 +8,6 @@ import lombok.Setter;
 public class TopicListDto { //카테고리안 토픽
     private Long topicId;
     private String title;
+    private String tag;
 }
 

--- a/src/main/java/com/example/jammoney/theme/entity/LearningTopic.java
+++ b/src/main/java/com/example/jammoney/theme/entity/LearningTopic.java
@@ -23,6 +23,8 @@ public class LearningTopic {
     @Column(columnDefinition = "TEXT")
     private String description;
 
+    private String tag;
+
     @ManyToOne
     @JoinColumn(name = "theme_id")
     private Theme theme;

--- a/src/main/java/com/example/jammoney/theme/service/LearningTopicService.java
+++ b/src/main/java/com/example/jammoney/theme/service/LearningTopicService.java
@@ -27,6 +27,7 @@ public class LearningTopicService {
                     TopicListDto dto = new TopicListDto();
                     dto.setTopicId(topic.getId());
                     dto.setTitle(topic.getTitle());
+                    dto.setTag(topic.getTag()); // tag 포함
                     return dto;
                 })
                 .toList();
@@ -40,6 +41,7 @@ public class LearningTopicService {
         dto.setTopicId(topic.getId());
         dto.setTitle(topic.getTitle());
         dto.setDescription(topic.getDescription());
+        dto.setTag(topic.getTag()); // tag 포함
         return dto;
     }
 
@@ -50,6 +52,7 @@ public class LearningTopicService {
         LearningTopic topic = LearningTopic.builder()
                 .title(dto.getTitle())
                 .description(dto.getDescription())
+                .tag(dto.getTag()) // tag 포함
                 .theme(theme)
                 .build();
 


### PR DESCRIPTION
## 📌 PR 제목

<테마별 학습 기능 태그 추가>

## 🛠️ 작업한 기능
- LearningTopic 엔티티에 tag 필드 추가
- 토픽 생성 시 tag 값 포함하도록 DTO 및 Service 로직 수정
- 토픽 목록 조회 및 상세 조회 시 tag 정보 포함되도록 DTO 확장 및 반환 구조 수정

## ✅ 테스트 내역
- Postman으로 토픽 생성 요청 (POST /api/themes/topics) → 정상 200 응답 
- 토픽 목록 조회 (GET /api/themes/{themeId}/topics) 시 tag 포함 확인
- 토픽 상세 조회 (GET /api/themes/{themeId}/topics/{topicId}/details) 시 tag 노출 확인

<img width="263" alt="테마별학습기능" src="https://github.com/user-attachments/assets/65229319-cbd3-42f3-8364-195b3126602f" />

