### PR TITLE
카테고리 순서 저장

### DIFF
--- a/src/main/java/com/example/jammoney/financeTerm/service/FinanceTermService.java
+++ b/src/main/java/com/example/jammoney/financeTerm/service/FinanceTermService.java
@@ -32,7 +32,7 @@ public class FinanceTermService {
     // 1. 카테고리 전체 조회 (지정된 순서대로 정렬)
     public List<CategoryDto> getAllCategories() {
         List<String> fixedOrder = List.of(
-                "소비", "저축", "대출", "투자", "보험", "세금", "금융기관&제도", "나만의 금융단어장"
+                "소비", "저축", "대출", "투자", "보험", "세금", "금융기관&제도"
         );
 
         List<CategoryDto> allCategories = categoryRepository.findAll().stream().map(c -> {
@@ -50,6 +50,7 @@ public class FinanceTermService {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
+
 
 
     public List<Integer> getAvailableDayIndexes(String categoryName) {


### PR DESCRIPTION
## 📌 PR 제목

<금융단어장 카테고리 순서 고정>

## 🛠️ 작업한 기능
- getAllCategories() 서비스 메서드에서 고정된 카테고리 순서로 정렬되도록 변경

## 📝 참고사항 (리뷰 시 유의할 점)
- 프론트 재요청사항에 따라 올린 PR 에서 카테고리 목록 하나만 제거했기 때문에 테스트 따로 하지 않았습니다! 