### PR TITLE
stock_min 데이터 저장 방식 수정

### DIFF
--- a/src/main/java/com/example/jammoney/stockApp/kis/service/ApiCallService.java
+++ b/src/main/java/com/example/jammoney/stockApp/kis/service/ApiCallService.java
@@ -92,7 +92,7 @@ public class ApiCallService {
                 .queryParam("FID_INPUT_ISCD", stockCode)
                 .queryParam("FID_ETC_CLS_CODE", "")
                 .queryParam("FID_INPUT_HOUR_1", time)
-                .queryParam("FID_PW_DATA_INCU_YN", "Y")
+                .queryParam("FID_PW_DATA_INCU_YN", "N")
                 .toUriString();
 
         return sendGet(uri, headers, StockMinDto.class);

--- a/src/main/java/com/example/jammoney/stockApp/stock/entity/StockMin.java
+++ b/src/main/java/com/example/jammoney/stockApp/stock/entity/StockMin.java
@@ -7,46 +7,51 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 
 @Entity
+@Table(
+        name = "stock_min",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"COMPANY_ID", "stock_trade_time"})
+)
+
 @Getter
 @Setter
 @NoArgsConstructor
 public class StockMin {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long stockMinId;
 
     @ManyToOne
-    @JoinColumn(name = "COMPANY_ID")
+    @JoinColumn(name = "COMPANY_ID", nullable = false)
     private Company company;
 
+    @Column(nullable = false)
     private LocalDateTime stockTradeTime;
 
-    //주식 체결 시간(문자열)
+    // 주식 체결 시간(문자열)
     private String stck_cntg_hour;
 
-    //주식 종가
+    // 주식 종가
     private String stck_prpr;
 
-    //주식 시가
+    // 주식 시가
     private String stck_oprc;
 
-    //주식 고가
+    // 주식 고가
     private String stck_hgpr;
 
-    //주식 저가
+    // 주식 저가
     private String stck_lwpr;
 
-    //체결 거래량
+    // 체결 거래량
     private String cntg_vol;
-    public void setTradeTime(LocalDateTime now) {
 
-        // 문자열에서 시, 분, 초 추출
+    public void setTradeTime(LocalDateTime now) {
         int hour = Integer.parseInt(this.stck_cntg_hour.substring(0, 2));
         int minute = Integer.parseInt(this.stck_cntg_hour.substring(2, 4));
         int second = Integer.parseInt(this.stck_cntg_hour.substring(4, 6));
 
-        // LocalDateTime 객체 생성
-        LocalDateTime customDateTime = LocalDateTime.of(
+        this.stockTradeTime = LocalDateTime.of(
                 now.getYear(),
                 now.getMonth(),
                 now.getDayOfMonth(),
@@ -54,8 +59,7 @@ public class StockMin {
                 minute,
                 second
         );
-
-        this.stockTradeTime = customDateTime;
     }
 }
+
 

--- a/src/main/java/com/example/jammoney/stockApp/stock/repository/StockMinRepository.java
+++ b/src/main/java/com/example/jammoney/stockApp/stock/repository/StockMinRepository.java
@@ -2,12 +2,33 @@ package com.example.jammoney.stockApp.stock.repository;
 
 import com.example.jammoney.stockApp.stock.entity.StockMin;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface StockMinRepository extends JpaRepository<StockMin, Long> {
     List<StockMin> findAllByCompany_CompanyId(Long companyId);
     @Query(value = "SELECT * FROM stock_min s WHERE s.company_id = ?1 ORDER BY s.stock_min_id DESC LIMIT 420", nativeQuery = true)
     List<StockMin> findTop420ByCompanyIdOrderByStockMinIdDesc(Long companyId);
+
+    @Modifying
+    @Query(value = """
+        INSERT IGNORE INTO stock_min 
+        (COMPANY_ID, stock_trade_time, stck_cntg_hour, stck_prpr, stck_oprc, stck_hgpr, stck_lwpr, cntg_vol)
+        VALUES 
+        (:companyId, :stockTradeTime, :stckCntgHour, :stckPrpr, :stckOprc, :stckHgpr, :stckLwpr, :cntgVol)
+        """, nativeQuery = true)
+    void insertIgnore(
+            @Param("companyId") Long companyId,
+            @Param("stockTradeTime") LocalDateTime stockTradeTime,
+            @Param("stckCntgHour") String stckCntgHour,
+            @Param("stckPrpr") String stckPrpr,
+            @Param("stckOprc") String stckOprc,
+            @Param("stckHgpr") String stckHgpr,
+            @Param("stckLwpr") String stckLwpr,
+            @Param("cntgVol") String cntgVol
+    );
 }

--- a/src/main/java/com/example/jammoney/stockApp/stock/service/StockMinService.java
+++ b/src/main/java/com/example/jammoney/stockApp/stock/service/StockMinService.java
@@ -16,10 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -38,43 +35,41 @@ public class StockMinService {
         List<Company> companyList = companyService.findAllCompanies();
         LocalDateTime now = LocalDateTime.now();
         String strHour = Time.strHour(now);
-        int i = 0;
+
         for (Company company : companyList) {
-            // 분봉 API 호출
-            log.info("Company Code : {}", company.getCode());
             StockMinDto stockMinDto = apiCallService.getStockMin(company.getCode(), strHour);
-            log.info("get api from kis complete. : {}", company.getCode());
-            // 분봉 리스트 매핑 및 저장
-            List<StockMin> stockMinList = stockMinDto.getOutput2().stream()
-                    .filter(dto -> dto.getStck_cntg_hour() != null)  // null 방지
-                    .map(stockMinOutput2 -> {
-                        StockMin stockMin = apiMapper.stockMinOutput2ToStockMin(stockMinOutput2);
+
+            List<StockMin> stockMinList = Optional.ofNullable(stockMinDto.getOutput2())
+                    .orElse(Collections.emptyList())
+                    .stream()
+                    .filter(dto -> dto.getStck_cntg_hour() != null)
+                    .map(dto -> {
+                        StockMin stockMin = apiMapper.stockMinOutput2ToStockMin(dto);
                         stockMin.setCompany(company);
                         stockMin.setTradeTime(now);
                         return stockMin;
                     })
-                    .sorted(Comparator.comparing(StockMin::getStockTradeTime))
-                    .collect(Collectors.toList());
+                    .toList();
 
-            stockMinRepository.saveAll(stockMinList);
-            log.info("complete_count : {}", i++);
-
-            // StockInfo 생성 및 기존 ID 세팅
-            StockInfo stockInfo = apiMapper.stockMinOutput1ToStockInfo(stockMinDto.getOutput1());
-            stockInfo.setCompany(company);
-
-            StockInfo oldStockInfo = company.getStockInfo();
-            if (oldStockInfo != null) {
-                stockInfo.setStockInfoId(oldStockInfo.getStockInfoId());  // UPDATE로 처리되게 함
+            for (StockMin stockMin : stockMinList) {
+                stockMinRepository.insertIgnore(
+                        stockMin.getCompany().getCompanyId(),
+                        stockMin.getStockTradeTime(),
+                        stockMin.getStck_cntg_hour(),
+                        stockMin.getStck_prpr(),
+                        stockMin.getStck_oprc(),
+                        stockMin.getStck_hgpr(),
+                        stockMin.getStck_lwpr(),
+                        stockMin.getCntg_vol()
+                );
             }
-
-            company.setStockInfo(stockInfo);
-            companyService.saveCompany(company);  // cascade로 stockInfo도 같이 저장
 
             Thread.sleep(500);
         }
+
         log.info("StockMin update finished");
     }
+
     public List<StockMin> getChart(long companyId) {
 
         return stockMinRepository.findAllByCompany_CompanyId(companyId);


### PR DESCRIPTION
## 📌 PR 제목

[hotfix] company_id, stock_trade_time이 일치하는 데이터는 db에 저장하지 않도록 수정

---

## 🛠️ 작업한 기능
- 동일한 데이터가 중복해서 들어가는 현상 막음

---

## ✅ 테스트 내역
- db 확인을 통해 중복 데이터는 포함되지 않는 걸 확인함
---

## 📎 관련 이슈
<!-- ex) close #12 -->

---

## 📝 참고사항 (리뷰 시 유의할 점)
<!-- 
예시:
- DB 쿼리는 임시이며 추후 QueryDSL 전환 예정
- 프론트와 응답 구조 조율 필요
-->

---

## 🎥 UI 변경 시 스크린샷 (선택)
<!-- 이미지 첨부 시 이곳에 넣어주세요 -->