### PR TITLE
퀴즈 조회시 자동 생성되도록 getOrCreateQuiz 로직 추가

### DIFF
--- a/src/main/java/com/example/jammoney/news/quiz/controller/NewsQuizController.java
+++ b/src/main/java/com/example/jammoney/news/quiz/controller/NewsQuizController.java
@@ -19,7 +19,13 @@ public class NewsQuizController {
     private final UserService userService;
     private final NewsQuizService quizService;
     private final UserRepository userRepository;
-    //퀴즈 생성 및 조회
+    //퀴즈 생성
+    @GetMapping
+    public NewsQuizDto getOrCreateQuiz(@PathVariable Long newsId) {
+        return quizService.getOrCreateQuiz(newsId);
+    }
+
+    //퀴즈 조회
     @PostMapping("/generate")
     public NewsQuizDto generateQuiz(@PathVariable Long newsId) {
         return quizService.generateAndSaveQuiz(newsId);

--- a/src/main/java/com/example/jammoney/news/quiz/service/NewsQuizService.java
+++ b/src/main/java/com/example/jammoney/news/quiz/service/NewsQuizService.java
@@ -12,4 +12,6 @@ public interface NewsQuizService {
     boolean checkAnswer(Long quizId, int selectedOptionIndex);
     NewsQuiz findQuizById(Long quizId);
     QuizResultDto submitQuiz(Long newsId, QuizSubmissionDto submission, User user);
+    NewsQuizDto getOrCreateQuiz(Long newsId);
+
 }

--- a/src/main/java/com/example/jammoney/news/quiz/service/NewsQuizServiceImpl.java
+++ b/src/main/java/com/example/jammoney/news/quiz/service/NewsQuizServiceImpl.java
@@ -32,6 +32,26 @@ public class NewsQuizServiceImpl implements NewsQuizService {
 
     @Transactional
     @Override
+    public NewsQuizDto getOrCreateQuiz(Long newsId) {
+        News news = newsRepo.findById(newsId)
+                .orElseThrow(() -> new IllegalArgumentException("뉴스가 없습니다. id=" + newsId));
+
+        return quizRepo.findByNews(news)
+                .map(quiz -> NewsQuizDto.builder()
+                        .quizId(quiz.getId())
+                        .question(quiz.getQuestion())
+                        .option1(quiz.getOption1())
+                        .option2(quiz.getOption2())
+                        .option3(quiz.getOption3())
+                        .option4(quiz.getOption4())
+                        .correctAnswerIndex(null)
+                        .build())
+                .orElseGet(() -> generateAndSaveQuiz(newsId));  // 없으면 생성
+    }
+
+
+    @Transactional
+    @Override
     public NewsQuizDto generateAndSaveQuiz(Long newsId) {
         News news = newsRepo.findById(newsId)
                 .orElseThrow(() -> new IllegalArgumentException("뉴스가 없습니다. id=" + newsId));
@@ -100,4 +120,6 @@ public class NewsQuizServiceImpl implements NewsQuizService {
         petService.addExp(user, 10);
         return new QuizResultDto(correct, quiz.getCorrectAnswerIndex());
     }
+
+
 }


### PR DESCRIPTION
## 📌 PR 제목

[Feature] 뉴스 퀴즈 조회 시 자동 생성되는 기능 추가

## 🛠️ 작업한 기능
- 뉴스 퀴즈 조회 API (GET /api/news/{newsId}/quiz) 호출 시 퀴즈가 없으면 자동 생성되도록 getOrCreateQuiz 로직 구현
- 프론트에서 GET 요청만으로 퀴즈 생성 및 조회가 가능하도록 API 통합

