### PR TITLE
LocalDateTime.now 기준을 우리나라로 설정

### DIFF
--- a/src/main/java/com/example/jammoney/stockApp/stock/service/StockMinService.java
+++ b/src/main/java/com/example/jammoney/stockApp/stock/service/StockMinService.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -33,7 +34,7 @@ public class StockMinService {
     @Transactional
     public void updateStockMin() throws InterruptedException {
         List<Company> companyList = companyService.findAllCompanies();
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
         String strHour = Time.strHour(now);
 
         for (Company company : companyList) {


### PR DESCRIPTION
## 📌 PR 제목

[hotfix] LocalDateTime.now 기준 우리나라로 설정

---

## 🛠️ 작업한 기능
- LocalDateTime.now 기준 우리나라로 설정

<!-- 
예시:
- 퀴즈 정답 시 EXP 및 가상 머니 보상 로직 추가
- `/api/quiz/submit` API 구현 및 응답 구조 설계
-->

---

## ✅ 테스트 내역
- [ ] 어떤 방식으로 테스트했는지 구체적으로 적어주세요.

<!-- 
예시:
- Postman으로 퀴즈 제출 테스트 (200 OK 확인)
- 브라우저에서 UI 클릭 시 리워드 지급 정상 확인
-->

---

## 📎 관련 이슈
<!-- ex) close #12 -->

---

## 📝 참고사항 (리뷰 시 유의할 점)
<!-- 
예시:
- DB 쿼리는 임시이며 추후 QueryDSL 전환 예정
- 프론트와 응답 구조 조율 필요
-->

---

## 🎥 UI 변경 시 스크린샷 (선택)
<!-- 이미지 첨부 시 이곳에 넣어주세요 -->