### PR TITLE
NewsService 수정

### DIFF
--- a/src/main/java/com/example/jammoney/news/service/NewsService.java
+++ b/src/main/java/com/example/jammoney/news/service/NewsService.java
@@ -65,9 +65,16 @@ public class NewsService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional
     public NewsResponseDto getNewsById(Long id) {
         News news = newsRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("뉴스를 찾을 수 없습니다. id=" + id));
+
+        if (news.getSummary() == null) {
+            String summary = gptSummaryClient.summarize(news.getContent());
+            news.setSummary(summary);
+            newsRepository.save(news);
+        }
 
         NewsResponseDto dto = new NewsResponseDto();
         dto.setId(news.getId());


### PR DESCRIPTION
## 📌 PR 제목

[Feature] 뉴스 크롤링 후 GPT 요약 저장 기능 추가

## 🛠️ 작업한 기능
- 저장된 요약을 /api/news/{id} GET 호출 시 summary 필드에 포함하여 반환

## 📝 참고사항 (리뷰 시 유의할 점)
gemma 구현은 제거하고 OpenAI GPT API만 사용합니다.

