### PR TITLE
feature/stockapp-ms

### DIFF
--- a/src/main/java/com/example/jammoney/stockApp/stock/controller/UserPortfolioController.java
+++ b/src/main/java/com/example/jammoney/stockApp/stock/controller/UserPortfolioController.java
@@ -27,7 +27,7 @@ public class UserPortfolioController {
         UserPortfolioResponseDto userPortfolioResponseDto;
         userPortfolioResponseDto = UserPortfolioResponseDto.builder()
                 .nickname(user.getNickname())
-                .money(portfolio.getCash().getMoney())
+                .money(user.getCash().getMoney())
                 .stockAsset(portfolio.getStockAsset())
                 .totalAsset(portfolio.getTotalAsset())
                 .profitAmount(portfolio.getProfitAmount())

--- a/src/main/java/com/example/jammoney/stockApp/stock/entity/UserPortfolio.java
+++ b/src/main/java/com/example/jammoney/stockApp/stock/entity/UserPortfolio.java
@@ -21,10 +21,6 @@ public class UserPortfolio {
     @JoinColumn(name = "user_id", unique = true)
     private User user;
 
-    @OneToOne
-    @JoinColumn(name = "cash_id", unique = true)
-    private Cash cash;
-
     // 보유 주식 자산 총액
     private long stockAsset;
 

--- a/src/main/java/com/example/jammoney/stockApp/stock/repository/UserPortfolioRepository.java
+++ b/src/main/java/com/example/jammoney/stockApp/stock/repository/UserPortfolioRepository.java
@@ -9,9 +9,5 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface UserPortfolioRepository extends JpaRepository<UserPortfolio, Long> {
-    @Query("SELECT up FROM UserPortfolio up JOIN FETCH up.cash JOIN FETCH up.user")
-    List<UserPortfolio> findAllWithCashAndUser();
     UserPortfolio findByUser(User user);
-    @Query("SELECT up FROM UserPortfolio up JOIN FETCH up.cash WHERE up.user = :user")
-    UserPortfolio findByUserWithCash(@Param("user") User user);
 }

--- a/src/main/java/com/example/jammoney/stockApp/stock/service/UserPortfolioService.java
+++ b/src/main/java/com/example/jammoney/stockApp/stock/service/UserPortfolioService.java
@@ -40,13 +40,13 @@ public class UserPortfolioService {
                 .mapToLong(HoldingStockResponseDto::getEvaluationAmount)
                 .sum();
 
-        long cash = user.getCash().getMoney();
+        long cash = user.getCash().getMoney(); // 직접 Cash 참조
         long totalAsset = cash + stockAsset;
 
         long investedAmount = holdingStockResponseDtos.stream()
                 .mapToLong(HoldingStockResponseDto::getTotalPrice)
                 .sum();
-        long profitAmount = stockAsset - investedAmount; //주식 평가금 - 매입금
+        long profitAmount = stockAsset - investedAmount;
         double profitRate = investedAmount > 0 ? (profitAmount / (double) investedAmount) * 100 : 0.0;
 
         UserPortfolio portfolio = userPortfolioRepository.findByUser(user);
@@ -55,7 +55,6 @@ public class UserPortfolioService {
             portfolio.setUser(user);
         }
 
-        portfolio.setCash(user.getCash());
         portfolio.setStockAsset(stockAsset);
         portfolio.setTotalAsset(totalAsset);
         portfolio.setProfitAmount(profitAmount);
@@ -64,7 +63,9 @@ public class UserPortfolioService {
         userPortfolioRepository.save(portfolio);
     }
 
+
+
     public UserPortfolio getPortfolio(User user) {
-        return userPortfolioRepository.findByUserWithCash(user);
+        return userPortfolioRepository.findByUser(user);
     }
 }

--- a/src/main/java/com/example/jammoney/user/service/UserService.java
+++ b/src/main/java/com/example/jammoney/user/service/UserService.java
@@ -59,7 +59,6 @@ public class UserService {
 
         UserPortfolio userPortfolio = UserPortfolio.builder()
                 .user(user)
-                .cash(user.getCash())
                 .stockAsset(0)
                 .totalAsset(0)
                 .profitAmount(0)

--- a/src/test/java/com/example/jammoney/stockApp/UserPortfolioServiceTest.java
+++ b/src/test/java/com/example/jammoney/stockApp/UserPortfolioServiceTest.java
@@ -108,7 +108,6 @@ class UserPortfolioServiceTest {
         // 5. UserPortfolio 저장
         UserPortfolio portfolio = new UserPortfolio();
         portfolio.setUser(user);
-        portfolio.setCash(user.getCash()); // 이제 확실히 insert된 cash
         userPortfolioRepository.save(portfolio);
 
         em.flush();
@@ -128,7 +127,7 @@ class UserPortfolioServiceTest {
         long expectedProfitAmount = expectedStockAsset - 600_000L;
         double expectedProfitRate = (expectedProfitAmount / (double) 600_000L) * 100;
 
-        assertEquals(1_000_000L, result.getCash().getMoney());
+        assertEquals(1_000_000L, result.getUser().getCash().getMoney());
         assertEquals(expectedStockAsset, result.getStockAsset());
         assertEquals(expectedTotalAsset, result.getTotalAsset());
         assertEquals(expectedProfitAmount, result.getProfitAmount());
@@ -147,7 +146,7 @@ class UserPortfolioServiceTest {
         // then
         UserPortfolio result = userPortfolioRepository.findByUser(user);
         assertEquals(2_000_000L + 500_000L, result.getTotalAsset());
-        assertEquals(2_000_000L, result.getCash().getMoney());
+        assertEquals(2_000_000L, result.getUser().getCash().getMoney());
     }
 
     @Test


### PR DESCRIPTION
## 📌 PR 제목

[refact] userPortfolio의 cash 필드 삭제

---

## 🛠️ 작업한 기능
- userPortfolio의 cash 필드 삭제에 의한 코드 수정
- cash 엔티티를 조인하는 방식이 아닌, user_id를 이용해 user의 cash 정보를 가져오도록 함

<!-- 
예시:
- 퀴즈 정답 시 EXP 및 가상 머니 보상 로직 추가
- `/api/quiz/submit` API 구현 및 응답 구조 설계
-->

---

## ✅ 테스트 내역
- [ ] 어떤 방식으로 테스트했는지 구체적으로 적어주세요.

<!-- 
예시:
- Postman으로 퀴즈 제출 테스트 (200 OK 확인)
- 브라우저에서 UI 클릭 시 리워드 지급 정상 확인
-->

---

## 📎 관련 이슈
<!-- ex) close #12 -->

---

## 📝 참고사항 (리뷰 시 유의할 점)
<!-- 
예시:
- DB 쿼리는 임시이며 추후 QueryDSL 전환 예정
- 프론트와 응답 구조 조율 필요
-->

---

## 🎥 UI 변경 시 스크린샷 (선택)
<!-- 이미지 첨부 시 이곳에 넣어주세요 -->