### PR TITLE
hotfix : 스케줄러 시간 한국 기준으로 고정 및 서버 실행시 크롤링 로직 실행되는 거 주석 처리

### DIFF
--- a/src/main/java/com/example/jammoney/news/scheduler/NewsScheduler.java
+++ b/src/main/java/com/example/jammoney/news/scheduler/NewsScheduler.java
@@ -17,7 +17,7 @@ public class NewsScheduler {
     private final FinanceNewsCrawler crawler;
     private final NewsService newsService;
 
-    @Scheduled(cron = "0 0 8 * * *") // 매일 오전 8시 실행
+    @Scheduled(cron = "0 0 8 * * *", zone = "Asia/Seoul") // 매일 오전 8시 실행
     public void crawlAndSave() {
         newsService.deleteOldNews(); // 7일 초과 뉴스 삭제
         List<NewsRequestDto> todayNews = crawler.fetchTodayNews();

--- a/src/main/java/com/example/jammoney/news/scheduler/NewsStartupRunner.java
+++ b/src/main/java/com/example/jammoney/news/scheduler/NewsStartupRunner.java
@@ -23,12 +23,10 @@ public class NewsStartupRunner implements ApplicationListener<ApplicationReadyEv
 
     @Override
     public void onApplicationEvent(ApplicationReadyEvent event) {
-        LocalDate today = LocalDate.now();
-        long countToday = newsService.countByPublishDate(today);
-
-        // 오전 8시 이후에, 오늘 크롤된 뉴스가 3개 미만이면 보충
-        List<NewsRequestDto> missing = crawler.fetchTodayNews();
-        newsService.saveNewsList(missing);
+//        LocalDate today = LocalDate.now();
+//        long countToday = newsService.countByPublishDate(today);
+//
+//        // 오전 8시 이후에, 오늘 크롤된 뉴스가 3개 미만이면 보충
 //        if (LocalTime.now().isAfter(LocalTime.of(8, 0)) && countToday < 3) {
 //            List<NewsRequestDto> missing = crawler.fetchTodayNews();
 //            newsService.saveNewsList(missing);


### PR DESCRIPTION
## 📌 PR 제목

[hotfix] 스케줄러 동작 시간 한국 기준 설정 및 서버 시작시 크롤링 로직 실행되는 거 주석 처리

---

## 🛠️ 작업한 기능
- [ ] 작업한 기능을 간단히 요약해주세요.

<!-- 
예시:
- 퀴즈 정답 시 EXP 및 가상 머니 보상 로직 추가
- `/api/quiz/submit` API 구현 및 응답 구조 설계
-->

---

## ✅ 테스트 내역
- [ ] 어떤 방식으로 테스트했는지 구체적으로 적어주세요.

<!-- 
예시:
- Postman으로 퀴즈 제출 테스트 (200 OK 확인)
- 브라우저에서 UI 클릭 시 리워드 지급 정상 확인
-->

---

## 📎 관련 이슈
<!-- ex) close #12 -->

---

## 📝 참고사항 (리뷰 시 유의할 점)
<!-- 
예시:
- DB 쿼리는 임시이며 추후 QueryDSL 전환 예정
- 프론트와 응답 구조 조율 필요
-->

---

## 🎥 UI 변경 시 스크린샷 (선택)
<!-- 이미지 첨부 시 이곳에 넣어주세요 -->